### PR TITLE
Make CheckTarballOperatingSystem() work with MySQL 4.1 and old 5.0

### DIFF
--- a/common/checks.go
+++ b/common/checks.go
@@ -140,6 +140,7 @@ func CheckTarballOperatingSystem(basedir string) {
 		isBinary bool
 	}
 	var findingList = map[string]OSFinding{
+		"libmysqlclient.a":             {"lib", "linux", "mysql", true}, // 4.1 and old 5.0 releases
 		"libmysqlclient.so":            {"lib", "linux", "mysql", true},
 		"libperconaserverclient.so":    {"lib", "linux", "percona", true},
 		"libperconaserverclient.dylib": {"lib", "darwin", "percona", true},


### PR DESCRIPTION
These releases don't have libmysqlclient.so on Linux but do have libmysqlclient.a

Tested with 4.1.22 and 5.0.15