### PR TITLE
Sandbox code is not easy to use outside dbdeployer #41

### DIFF
--- a/common/fileutil.go
+++ b/common/fileutil.go
@@ -335,6 +335,8 @@ func CopyFile(source, destination string) {
 // These lines should:
 // 1) Do not exit. Return errors instead.
 // 2) Wrappers for 1 single line will be removed to use errors instead
+// 3) I am commenting out these lines just to force a failure wherever they are being called. That way
+//    will be easier to detect all the places where they should be changed/removed.
 
 // func BaseName(filename string) string {
 // 	return filepath.Base(filename)

--- a/common/fileutil.go
+++ b/common/fileutil.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -333,31 +332,35 @@ func CopyFile(source, destination string) {
 	ErrCheckExitf(err, 1, "error copying from source %s to destination file %s: %s", source, destination, err)
 }
 
-func BaseName(filename string) string {
-	return filepath.Base(filename)
-}
+// These lines should:
+// 1) Do not exit. Return errors instead.
+// 2) Wrappers for 1 single line will be removed to use errors instead
 
-func DirName(filename string) string {
-	return filepath.Dir(filename)
-}
+// func BaseName(filename string) string {
+// 	return filepath.Base(filename)
+// }
+//
+// func DirName(filename string) string {
+// 	return filepath.Dir(filename)
+// }
 
-func AbsolutePath(value string) string {
-	filename, err := filepath.Abs(value)
-	ErrCheckExitf(err, 1, "error getting absolute path for %s", value)
-	return filename
-}
+// func AbsolutePath(value string) string {
+// 	filename, err := filepath.Abs(value)
+// 	ErrCheckExitf(err, 1, "error getting absolute path for %s", value)
+// 	return filename
+// }
 
-func Mkdir(dirName string) {
-	err := os.Mkdir(dirName, PublicDirectoryAttr)
-	ErrCheckExitf(err, 1, "error creating directory %s\n%s\n", dirName, err)
-}
+// func Mkdir(dirName string) {
+// 	err := os.Mkdir(dirName, PublicDirectoryAttr)
+// 	ErrCheckExitf(err, 1, "error creating directory %s\n%s\n", dirName, err)
+// }
 
-func Rmdir(dirName string) {
-	err := os.Remove(dirName)
-	ErrCheckExitf(err, 1, "error removing directory %s\n%s\n", dirName, err)
-}
-
-func RmdirAll(dirName string) {
-	err := os.RemoveAll(dirName)
-	ErrCheckExitf(err, 1, "error deep-removing directory %s\n%s\n", dirName, err)
-}
+// func Rmdir(dirName string) {
+// 	err := os.Remove(dirName)
+// 	ErrCheckExitf(err, 1, "error removing directory %s\n%s\n", dirName, err)
+// }
+//
+// func RmdirAll(dirName string) {
+// 	err := os.RemoveAll(dirName)
+// 	ErrCheckExitf(err, 1, "error deep-removing directory %s\n%s\n", dirName, err)
+// }

--- a/sandbox/group_replication.go
+++ b/sandbox/group_replication.go
@@ -284,9 +284,9 @@ func CreateGroupReplication(sandboxDef SandboxDef, origin string, nodes int, mas
 		sandboxDef.NodeNum = i
 		// fmt.Printf("%#v\n",sdef)
 		logger.Printf("Create single sandbox for node %d\n", i)
-		err, execList := CreateChildSandbox(sandboxDef)
+		execList, err := CreateSingleConcurrentSandbox(sandboxDef)
 		if err != nil {
-			return fmt.Errorf(defaults.ErrCreatingSandbox, err)
+			common.Exit(1, err.Error())
 		}
 		for _, list := range execList {
 			execLists = append(execLists, list)

--- a/sandbox/replication.go
+++ b/sandbox/replication.go
@@ -23,6 +23,7 @@ import (
 	"github.com/datacharmer/dbdeployer/common"
 	"github.com/datacharmer/dbdeployer/concurrent"
 	"github.com/datacharmer/dbdeployer/defaults"
+	"github.com/pkg/errors"
 )
 
 type Slave struct {
@@ -139,10 +140,11 @@ func CreateMasterSlaveReplication(sandboxDef SandboxDef, origin string, nodes in
 	sandboxDef.NodeNum = 1
 	sandboxDef.SBType = "replication-node"
 	logger.Printf("Creating single sandbox for master\n")
-	err, execList := CreateChildSandbox(sandboxDef)
+	execList, err := CreateSingleConcurrentSandbox(sandboxDef)
 	if err != nil {
-		return fmt.Errorf(defaults.ErrCreatingSandbox, err)
+		return errors.Wrap(err, "cannot create a single sandbox for master")
 	}
+
 	for _, list := range execList {
 		execLists = append(execLists, list)
 	}
@@ -313,8 +315,9 @@ func CreateMasterSlaveReplication(sandboxDef SandboxDef, origin string, nodes in
 			return err
 		}
 	}
-	fmt.Printf("Replication directory installed in %s\n", common.ReplaceLiteralHome(sandboxDef.SandboxDir))
-	fmt.Printf("run 'dbdeployer usage multiple' for basic instructions'\n")
+	// TODO: Improve logging
+	//fmt.Printf("Replication directory installed in %s\n", common.ReplaceLiteralHome(sandboxDef.SandboxDir))
+	//fmt.Printf("run 'dbdeployer usage multiple' for basic instructions'\n")
 	return nil
 }
 

--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -537,7 +537,11 @@ func createSingleSandbox(sandboxDef SandboxDef, runConcurrently bool) ([]concurr
 		}
 	}
 
-	writeScript(logger, SingleTemplates, defaults.ScriptInitDb, "init_db_template", sandboxDir, data, true)
+	err := writeScript(logger, SingleTemplates, defaults.ScriptInitDb, "init_db_template", sandboxDir, data, true)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot write init_db_template script")
+	}
+
 	if runConcurrently {
 		var eCommand = concurrent.ExecCommand{
 			Cmd:  path.Join(sandboxDir, defaults.ScriptInitDb),


### PR DESCRIPTION
This is just a proposal.
Proposed changes:

1) Return error wherever we can instead of calling `os.Exit`. Following Go convention, errors should be the last value returned by a function so, we shouldn't return `error, value`, we should return `value, error` instead.
2) Improve logging. I know this is part of a bigger project and maybe in the future big functions like CreateSingleSandbox should be splitted in smaller/testeable code.
3) I am commenting out some wrappers to force an error wherever they are being called from, to make it easier to detect all places where a change will be affect the rest of the code.