### PR TITLE
Avoid socket authentication on MariaDB 10.4.3 and newer

### DIFF
--- a/common/capabilities.go
+++ b/common/capabilities.go
@@ -68,6 +68,7 @@ const (
 	NativeAuth       = "nativeAuth"
 	DataDict         = "datadict"
 	XtradbCluster    = "xtradbCluster"
+	RootAuth         = "rootAuth"
 )
 
 var MySQLCapabilities = Capabilities{
@@ -269,6 +270,10 @@ var MariadbCapabilities = Capabilities{
 			Description: "uses mysql_install_db",
 			Since:       globals.MinimumMySQLInstallDb,
 			Until:       nil,
+		},
+		RootAuth: {
+			Description: "Root Authentication during install",
+			Since:       globals.MinimumRootAuthVersion,
 		},
 		DynVariables: MySQLCapabilities.Features[DynVariables],
 		SemiSynch:    MySQLCapabilities.Features[SemiSynch],

--- a/globals/globals.go
+++ b/globals/globals.go
@@ -258,6 +258,7 @@ var (
 	MariaDbMinimumGtidVersion        = []int{10, 0, 0}
 	MariaDbMinimumMultiSourceVersion = []int{10, 0, 0}
 	MinimumXtradbClusterVersion      = []int{5, 7, 14}
+	MinimumRootAuthVersion           = []int{10, 4, 3}
 )
 
 const (

--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -490,6 +490,14 @@ func createSingleSandbox(sandboxDef SandboxDef) (execList []concurrent.Execution
 			logger.Printf("Using mysql_native_password for authentication\n")
 		}
 	}
+	// MariaDB 10.4.3 defaults to socket auth
+	isMinimumRootAuth, err := common.HasCapability(sandboxDef.Flavor, common.RootAuth, sandboxDef.Version)
+	if err != nil {
+		return emptyExecutionList, err
+	}
+	if isMinimumRootAuth {
+		sandboxDef.InitOptions = append(sandboxDef.InitOptions, "--auth-root-authentication-method=normal")
+	}
 	// 8.0.11
 	// isMinimumMySQLXDefault, err = common.GreaterOrEqualVersion(sandboxDef.Version, globals.MinimumMysqlxDefaultVersion)
 	isMinimumMySQLXDefault, err = common.HasCapability(sandboxDef.Flavor, common.MySQLXDefault, sandboxDef.Version)


### PR DESCRIPTION
Socket auth works fine if you install as the UNIX root user, but
not if you install with some other user.

This setups the root@localhost to not use socket auth during installation
by calling `mysql_install_db` with the `--auth-root-authentication-method=normal`
option.

Issue: #67
See also: https://mariadb.com/kb/en/library/authentication-plugin-unix-socket/