### PR TITLE
Fix PXC compatibility with 5.6

### DIFF
--- a/sandbox/pxc_replication.go
+++ b/sandbox/pxc_replication.go
@@ -29,6 +29,7 @@ import (
 )
 
 var pxcReplicationOptions string = `
+log_slave_updates
 innodb_file_per_table
 innodb_autoinc_lock_mode=2
 wsrep-provider=__BASEDIR__/lib/libgalera_smm.so


### PR DESCRIPTION
It needs log_slave_updates, which makes sense to keep even for later
versions as we were using binlogs anyway