### PR TITLE
Fix for hang when executing "ldconfig -p"

### DIFF
--- a/common/fileutil.go
+++ b/common/fileutil.go
@@ -503,19 +503,13 @@ func runCmdCtrlArgs(c string, silent bool, args ...string) (string, string, erro
 	if err != nil {
 		return "", "", err
 	}
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return "", "", err
-	}
 
-	err = cmd.Start()
+	slurpOut, err := cmd.Output()
 	if err != nil {
 		return "", "", err
 	}
 
 	slurpErr, _ := ioutil.ReadAll(stderr)
-	slurpOut, _ := ioutil.ReadAll(stdout)
-	err = cmd.Wait()
 
 	if err != nil {
 		CondPrintf("cmd:    %s\n", c)


### PR DESCRIPTION
Hi Giuseppe-san,

Reverting cmd.Start() to cmd.Output(). cmd.Start() causes EAGAIN against ioutil.ReadAll(). Since the code did't have any error handling routine, the code waited at line 518 forever due to EAGAIN.

I'm not certain about why EAGAIN is caused by ioutil.ReadAll(). I guess that the new process for ldconfig is not ready when reading from the pipe. This could be a race.

Kind regards,
Mikiya