### PR TITLE
Fix --use-template to not require _template suffix

### DIFF
--- a/cmd/single.go
+++ b/cmd/single.go
@@ -31,7 +31,8 @@ import (
 )
 
 func replaceTemplate(templateName string, fileName string) {
-	group, _, contents := findTemplate(templateName)
+	// Use the canonical name for the template returned by findTemplate
+	group, templateName, contents := findTemplate(templateName)
 	if !common.FileExists(fileName) {
 		common.Exitf(1, globals.ErrFileNotFound, fileName)
 	}


### PR DESCRIPTION
When using `dbdeployer deploy --use-template`, the current code will
accept either e.g. 'init_slaves' or 'init_slaves_template', but only the
latter will actually have an effect.

This is because findTemplate will return a match if
templateName+"_template" is a known template, but replaceTemplate still
uses the original templateName to store the updated template.