### PR TITLE
Script to generate downloads json entries

### DIFF
--- a/scripts/get_dbdeployer_mysql_json.sh
+++ b/scripts/get_dbdeployer_mysql_json.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+
+# Bash script generating JSON entry
+# for dbdeployer's downloads list
+
+# v0.1
+
+# 2021-04-30 - lefred - v0.1
+
+
+categories=(mysql shell cluster)
+os="Linux"
+agent="Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:59.0) Gecko/20100101 Firefox/59.0" 
+
+if [[ $# -lt 2 ]]
+then
+    echo "ERROR: two arguments are requires and the 3rd is optional !"
+    echo "       $(basename $0) <mysql|cluster|shell> <version> <Linux|Darwin>"
+    exit 1
+fi
+
+if ! [[ ${categories[*]} =~ $1 ]]
+then
+    echo "ERROR: $1 is not a correct category (mysql|cluster|shell) !!"
+    exit 2
+fi
+if [[ ${3,,} == "darwin" || ${3,,} == "macos" || ${3,,} == "mac" ]]
+then
+    os="Darwin"
+    agent="User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_1) AppleWebKit/537.36 (K HTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36"
+fi
+
+
+url="https://dev.mysql.com/downloads/$1/"
+url_file="https://dev.mysql.com/get/Downloads"
+case $1 in
+    mysql)
+        flavor="mysql"
+        to_grep="minimal.tar.xz"
+        minimal="true"
+        if [[ "$os" == "Darwin" ]]
+        then
+            to_grep="tar.gz"
+            minimal="false"
+        fi
+        if ! [[ $2 == 8* || $2 == 5.7* ]]
+        then
+                echo "ERROR: invalid version !"
+                exit 3
+        fi
+        if [[ $2 == 5* ]];
+        then
+            if [[ "$os" == "Darwin" ]]
+            then
+                echo "ERROR: no MySQL Server for MacOS for this version !"
+                exit 3
+            fi
+            url="https://dev.mysql.com/downloads/mysql/5.7.html"
+            to_grep="_64.tar.gz"
+            minimal="false"
+        fi
+        for line in "$(curl -s -A "$agent" $url | html2text | grep $to_grep -A 1| grep mysql-[0-9] -A 1)"
+        do
+            file=$(echo $line | awk '{print substr($1, 2, length($1) - 2)}')
+            if [[ $file == *$2*   ]]
+            then
+                checksum=$(echo $line | awk '{print substr($4, 2, length($4) - 2)}')
+                url_file_2="MySQL-${2:0:3}"
+                size=$(curl -s -I -L  ${url_file}/${url_file_2}/$file | grep Content-Len | cut -d' ' -f 2)
+            fi
+        done
+        version=$(echo $file| cut -d'-' -f2)
+        ;;
+    shell)
+        flavor="shell"
+        minimal="false"
+        to_grep="64bit.tar.gz"
+        if ! [[ $2 == 8* ]]
+        then
+                echo "ERROR: invalid version, only 8 is supported!"
+                exit 3
+        fi
+        if [[ "$os" == "Darwin" ]]
+        then
+            to_grep="tar.gz"
+        fi
+        for line in "$(curl -s -A "$agent" $url | html2text | grep $to_grep -A 1)"
+        do
+            file=$(echo $line | awk '{print substr($1, 2, length($1) - 2)}')
+            if [[ $file == *$2*   ]]
+            then
+                checksum=$(echo $line | awk '{print substr($4, 2, length($4) - 2)}')
+                url_file_2="MySQL-Shell"
+                size=$(curl -s -I -L  ${url_file}/${url_file_2}/$file | grep Content-Len | cut -d' ' -f 2)
+            fi
+        done
+        version=$(echo $file| cut -d'-' -f3)
+        ;;
+    cluster)
+        flavor="ndb"
+        to_grep="x86_64.tar.gz)"
+        minimal="false"
+        if [[ "$os" == "Darwin" ]]
+        then
+            to_grep="tar.gz"
+        fi
+        if ! [[ $2 == 8* || $2 == 7* ]]
+        then
+                echo "ERROR: invalid version !"
+                exit 3
+        fi
+
+        if [[ $2 == 7* ]];
+        then
+            if [[ "$os" == "Darwin" ]]
+            then
+                echo "ERROR: no MySQL Cluster for MacOS for this version !"
+                exit 3
+            fi
+            url="https://dev.mysql.com/downloads/cluster/7.6.html"
+        fi
+        for line in "$(curl -s -A "$agent" $url | html2text | grep $to_grep -A 1| grep mysql-cluster -A 1)"
+        do
+            file=$(echo $line | awk '{print substr($1, 2, length($1) - 2)}')
+            if [[ $file == *$2*   ]]
+            then
+                checksum=$(echo $line | awk '{print substr($4, 2, length($4) - 2)}')
+                url_file_2="MySQL-Cluster-${2:0:3}"
+                size=$(curl -s -I -L  ${url_file}/${url_file_2}/$file | grep Content-Len | cut -d' ' -f 2)
+            fi
+        done
+        version=$(echo $file| cut -d'-' -f3)
+        if [[ $2 == 7* ]];
+        then
+            version=$(echo $file| cut -d'-' -f4)
+        fi
+        ;;
+    *)
+        echo "Not yet implemented"
+        ;;
+esac
+
+date_added=$(date +"%F %H:%M")
+cat << EOL
+     {
+       "name": "$file",
+       "checksum": "MD5:$checksum",
+       "OS": "$os",
+       "url": " ${url_file}/${url_file_2}/$file",
+       "flavor": "$flavor",
+       "minimal": $minimal,
+       "size": ${size::-1},
+       "short_version": "${version:0:3}",
+       "version": "$version",
+       "notes": "added by lefred",
+       "date_added": "$date_added"
+      }
+EOL
+
+

--- a/scripts/get_dbdeployer_mysql_json.sh
+++ b/scripts/get_dbdeployer_mysql_json.sh
@@ -152,8 +152,7 @@ cat << EOL
        "size": ${size::-1},
        "short_version": "${version:0:3}",
        "version": "$version",
-       "notes": "added by lefred",
+       "notes": "added by  get_dbdeployer_mysql_json.sh",
        "date_added": "$date_added"
       }
 EOL
-

--- a/scripts/get_dbdeployer_mysql_json.sh
+++ b/scripts/get_dbdeployer_mysql_json.sh
@@ -1,12 +1,23 @@
 #!/usr/bin/env bash
-
-# Bash script generating JSON entry
-# for dbdeployer's downloads list
+# Bash script generating JSON entry for DBdeployer's downloads list
+# Copyright © 2021 lefred <lefred.descamps@gmail.com>
 
 # v0.1
 
 # 2021-04-30 - lefred - v0.1
 
+html2text_run=$(which html2text 2>/dev/null)
+if [[ $? -ne 0 ]]
+then
+    echo "ERROR: please install html2text (>=2.0)"
+    exit 5
+fi
+html2text_ver=$($html2text_run --version | awk '{print $NF}' | cut -d'.' -f1)
+if [[ $html2text_ver -lt 2 ]]
+then
+    echo "ERROR: please install html2text (>=2.0) - current version is $html2text_ver"
+    exit 5
+fi
 
 categories=(mysql shell cluster)
 os="Linux"

--- a/scripts/get_dbdeployer_mysql_json.sh
+++ b/scripts/get_dbdeployer_mysql_json.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Bash script generating JSON entry for DBdeployer's downloads list
+# Bash script generating JSON entry for DBDeployer's downloads list
 # Copyright © 2021 lefred <lefred.descamps@gmail.com>
 
 # v0.1

--- a/scripts/get_dbdeployer_mysql_json.sh
+++ b/scripts/get_dbdeployer_mysql_json.sh
@@ -163,7 +163,7 @@ cat << EOL
        "size": ${size::-1},
        "short_version": "${version:0:3}",
        "version": "$version",
-       "notes": "added by  get_dbdeployer_mysql_json.sh",
+       "notes": "added by get_dbdeployer_mysql_json.sh",
        "date_added": "$date_added"
       }
 EOL

--- a/scripts/get_dbdeployer_mysql_json.sh
+++ b/scripts/get_dbdeployer_mysql_json.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Bash script generating JSON entry
 # for dbdeployer's downloads list
@@ -156,5 +156,4 @@ cat << EOL
        "date_added": "$date_added"
       }
 EOL
-
 


### PR DESCRIPTION
this bash script helps to generate json entries for the download list for MySQL (Server, Shell and Cluster)

it supports Linux (default) and MacOSX (Darrwin) 

some example:

```
$ ./get_dbdeployer_mysql_json.sh shell 8 mac
     {
       "name": "mysql-shell-8.0.24-macos11-x86-64bit.tar.gz",
       "checksum": "MD5:724010111e3c749343bf15b9468160d2",
       "OS": "Darwin",
       "url": " https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-8.0.24-macos11-x86-64bit.tar.gz",
       "flavor": "shell",
       "minimal": false,
       "size": 38230437,
       "short_version": "8.0",
       "version": "8.0.24",
       "notes": "added by lefred",
       "date_added": "2021-04-30 15:27"
      }

$ ./get_dbdeployer_mysql_json.sh mysql 8 
     {
       "name": "mysql-8.0.24-linux-glibc2.17-x86_64-minimal.tar.xz",
       "checksum": "MD5:ff9c0d623c7568a645473200b7c1aba7",
       "OS": "Linux",
       "url": " https://dev.mysql.com/get/Downloads/MySQL-8/mysql-8.0.24-linux-glibc2.17-x86_64-minimal.tar.xz",
       "flavor": "mysql",
       "minimal": true,
       "size": 51222772,
       "short_version": "8.0",
       "version": "8.0.24",
       "notes": "added by lefred",
       "date_added": "2021-04-30 15:27"
      }

$ ./get_dbdeployer_mysql_json.sh cluster 7
     {
       "name": "mysql-cluster-gpl-7.6.18-linux-glibc2.12-x86_64.tar.gz",
       "checksum": "MD5:ba54f1cf6e0c338ddc967c2d5f8dde75",
       "OS": "Linux",
       "url": " https://dev.mysql.com/get/Downloads/MySQL-Cluster-7/mysql-cluster-gpl-7.6.18-linux-glibc2.12-x86_64.tar.gz",
       "flavor": "ndb",
       "minimal": false,
       "size": 936396172,
       "short_version": "7.6",
       "version": "7.6.18",
       "notes": "added by lefred",
       "date_added": "2021-04-30 15:31"
      }
      
```
