### PR TITLE
Allow other custom mysqld than mysqld-debug

### DIFF
--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -538,10 +538,12 @@ func createSingleSandbox(sandboxDef SandboxDef) (execList []concurrent.Execution
 				customMysqld, sandboxDef.CustomMysqld)
 		}
 		pluginDebugDir := fmt.Sprintf("%s/lib/plugin/debug", sandboxDef.Basedir)
-		if sandboxDef.CustomMysqld == "mysqld-debug" && common.DirExists(pluginDebugDir) {
-			sandboxDef.MyCnfOptions = append(sandboxDef.MyCnfOptions, fmt.Sprintf("plugin-dir=%s", pluginDebugDir))
-		} else {
-			rightPluginDir = false
+		if sandboxDef.CustomMysqld == "mysqld-debug" {
+			if common.DirExists(pluginDebugDir) {
+				sandboxDef.MyCnfOptions = append(sandboxDef.MyCnfOptions, fmt.Sprintf("plugin-dir=%s", pluginDebugDir))
+			} else {
+				rightPluginDir = false
+			}
 		}
 	}
 	// 5.1.0


### PR DESCRIPTION
Only require the debug plugin directory when the custom mysqld actually is "mysqld-debug"